### PR TITLE
Update _spectral_py.py

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1723,6 +1723,19 @@ def cyclic_sd(x, y, *, fs=16., alpha=4., sym=True, window='hann', nperseg=None,
     if alpha > fs / 2:
         raise ValueError('Cyclic frequency must be inferior to Nyquist '
                          'frequency, got %s' % (alpha,))
+        
+    # to avoid artefacts in results noverlap >= nperseg // 4 * 3 
+    if (noverlap is None) and (nperseg is None):
+       nperseg = 256
+       noverlap = nperseg // 4 * 3
+    elif noverlap is None: 
+       noverlap = nperseg // 4 * 3
+    # this one does not promiss a fast fft
+    elif nperseg is None:
+       nperseg = noverlap * 4 // 3            
+
+    if (noverlap < nperseg // 4 * 3):
+        raise ValueError('To avoid leakge, overlap should be larger than 75%')
 
     if sym:
         y = y * np.exp(-1j * np.pi * (alpha / fs) * np.arange(y.shape[-1]))


### PR DESCRIPTION
protection against [leakage](https://dsp.stackexchange.com/questions/83096/how-to-eliminate-a-cyclic-spectrum-estimation-window-artifact). I am not sure that it is the best practice though. 

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
